### PR TITLE
Ajustes en los contenedores secciones y desborde de contenido

### DIFF
--- a/src/page/home/cursos.astro
+++ b/src/page/home/cursos.astro
@@ -7,7 +7,7 @@ import StackIcon from "@components/card/stack-icon.astro";
 
 <div
   id="cursos"
-  class="h-svh md:h-screen snap-start w-full px-5 py-20 md:px-10 flex flex-col items-center justify-evenly gap-0 lg:gap-8 overflow-hidden"
+  class="min-h-svh snap-start w-full px-5 py-20 md:px-10 flex flex-col items-center justify-evenly gap-0 lg:gap-8"
 >
   <div class="flex flex-col items-center justify-center gap-5">
     <h2

--- a/src/page/home/nosotros.astro
+++ b/src/page/home/nosotros.astro
@@ -6,7 +6,7 @@ import Logo from "@assets/logo.svg";
 
 <div
   id="nosotros"
-  class="h-svh md:h-screen snap-start w-full px-5 md:px-10 flex flex-col items-center justify-evenly"
+  class="min-h-svh snap-start w-full px-5 md:px-10 flex flex-col items-center justify-evenly"
 >
   <div class="flex flex-col items-center justify-center gap-5">
     <h2

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import Unete from "@page/home/unete.astro";
 ---
 
 <Layout>
-  <main class="h-screen overflow-y-scroll snap-y snap-mandatory">
+  <main class="h-screen overflow-y-scroll">
     <Banner />
     <Nosotros />
     <Cursos />


### PR DESCRIPTION
Eliminado del `snap-mandatory` y `snap-y` porque dificulta
la lectura de la página en móviles

Correción en los estilos de los contenedores de las secciones:
- **Nosotros**: desborde del contenido
- **Cursos**: _timeline_ no es visible por completo
<img width="636" height="396" alt="image" src="https://github.com/user-attachments/assets/fd9139b9-d7fc-41cc-a2c3-b1cf9353099d" />